### PR TITLE
Use / instead of \ in paths.

### DIFF
--- a/dmhud.cs
+++ b/dmhud.cs
@@ -1635,7 +1635,7 @@ public class KerbalFlightIndicators : MonoBehaviour
     public void LoadSettings()
     {
         ConfigNode settings = new ConfigNode();
-        settings = ConfigNode.Load(AssemblyLoader.loadedAssemblies.GetPathByType(typeof(KerbalFlightIndicators)) + @"\settings.cfg".Replace('/', '\\'));
+        settings = ConfigNode.Load(AssemblyLoader.loadedAssemblies.GetPathByType(typeof(KerbalFlightIndicators)) + @"/settings.cfg");
         if (settings != null)
         {
             if (settings.HasValue("active")) enableThroughToolbar = bool.Parse(settings.GetValue("active"));


### PR DESCRIPTION
Linux does not recognize \ as a path separator, while windows recognizes
both \ and / as one.

This fixes the problem of KFI not remembering the indicator state setting
on Linux.
