### PR TITLE
Fix version file min/max properties

### DIFF
--- a/Distribution/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version
+++ b/Distribution/GameData/KerbalFlightIndicators/KerbalFlightIndicators.version
@@ -10,14 +10,12 @@
         "MINOR": 11,
         "PATCH": 1
     },
-    "KSP_MIN_VERSION": {
+    "KSP_VERSION_MIN": {
         "MAJOR": 1,
-        "MINOR": 11,
-        "PATCH": 0
+        "MINOR": 11
     },
-    "KSP_MAX_VERSION": {
+    "KSP_VERSION_MAX": {
         "MAJOR": 1,
-        "MINOR": 11,
-        "PATCH": 999
+        "MINOR": 11
     }
 }


### PR DESCRIPTION
As noted by @DasSkelett in KSP-CKAN/NetKAN#8504, the property names should be `KSP_VERSION_MIN` and `KSP_VERSION_MAX`. Now this is fixed, and the `.999` is removed because it isn't needed.